### PR TITLE
Pick hostname by default for `who-can-create-meetings` and better error messages.

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -117,8 +117,10 @@ fn get_allowed_emails_or_host(
         .collect::<Vec<&str>>()
         .as_slice()
     {
-        // meet.fifthtry.com
-        [_, host, ext] => Some(format!("{}.{}", host, ext)),
+        // foo.bar.gov.in -> bar.gov.in
+        [.., subdomain, domain, ext1, ext2] => Some(format!("{}.{}.{}", domain, ext1, ext2)),
+        // meet.fifthtry.com -> fifthtry.com
+        [.., subdomain, domain, ext] => Some(format!("{}.{}", domain, ext)),
         // fifthtry.com/talk/
         [host, ext] => Some(format!("{}.{}", host, ext)),
         _ => None,
@@ -172,6 +174,13 @@ mod tests {
         assert_eq!(
             get_allowed_emails_or_host(allowed_emails, &host).unwrap(),
             "capybara.com"
+        );
+
+        let host = ft_sdk::Host("foo.bar.gov.in".to_string());
+        let allowed_emails = "".to_string();
+        assert_eq!(
+            get_allowed_emails_or_host(allowed_emails, &host).unwrap(),
+            "bar.gov.in"
         );
     }
 

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -76,28 +76,176 @@ impl RequiredUser {
     /// `require-verification` (true/false)
     ///
     /// If `require-verification` is set to true, then the user account must be verified
-    pub(crate) fn is_special(&self, config: &crate::Config) -> bool {
-        if config.allowed_emails.is_empty() {
-            ft_sdk::println!(
-                "`allowed-emails` list is empty. No one is allowed to create meetings"
-            );
-            return false;
+    pub(crate) fn is_special(
+        &self,
+        config: &crate::Config,
+        host: &ft_sdk::Host,
+    ) -> Result<(), AuthorizationError> {
+        let allowed_emails = get_allowed_emails_or_host(config.allowed_emails.clone(), host)?;
+
+        let email_matches = allowed_emails
+            .split(',')
+            .map(|v| v.trim())
+            .any(|v| !v.is_empty() && self.email.ends_with(v));
+
+        if !email_matches {
+            return Err(AuthorizationError::Unauthorized);
         }
 
-        config.allowed_emails.split(',').map(|v| v.trim()).any(|v| {
-            if v.is_empty() {
-                return false;
-            }
+        if config.require_verification && !self.email_is_verified {
+            return Err(AuthorizationError::RequiresVerification);
+        }
 
-            // check email domain
-            let email_matches = self.email.ends_with(v);
-            // if the email matches, check if the account is verified (verification is done
-            // by clicking on a link that is sent to user's email)
-            if config.require_verification {
-                return email_matches && self.email_is_verified;
-            }
+        Ok(())
+    }
+}
 
-            email_matches
-        })
+/// Get the allowed emails from the `who-can-create-meetings` ftd variable or the request host if
+/// it's empty
+/// Returns [AuthorizationError::EmptyWhitelist] if both are empty
+fn get_allowed_emails_or_host(
+    allowed_emails: String,
+    host: &ft_sdk::Host,
+) -> Result<String, AuthorizationError> {
+    if !allowed_emails.is_empty() {
+        return Ok(allowed_emails);
+    }
+
+    let domain = match host
+        .without_port()
+        .split('.')
+        .collect::<Vec<&str>>()
+        .as_slice()
+    {
+        // meet.fifthtry.com
+        [_, host, ext] => Some(format!("{}.{}", host, ext)),
+        // fifthtry.com/talk/
+        [host, ext] => Some(format!("{}.{}", host, ext)),
+        _ => None,
+    };
+
+    match domain {
+        Some(v) => Ok(v),
+        None => Err(AuthorizationError::EmptyWhitelist),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum AuthorizationError {
+    /// The logged in user is not in `who-can-create-meetings` ftd variable
+    Unauthorized,
+    /// The `who-can-create-meetings` ftd variable is empty
+    EmptyWhitelist,
+    /// The user needs to verify their email
+    RequiresVerification,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_allowed_emails_or_host() {
+        let host = ft_sdk::Host("meet.fifthtry.com".to_string());
+        let allowed_emails = "fifthtry.com".to_string();
+        assert_eq!(
+            get_allowed_emails_or_host(allowed_emails, &host).unwrap(),
+            "fifthtry.com"
+        );
+
+        let host = ft_sdk::Host("meet.fifthtry.com".to_string());
+        let allowed_emails = "".to_string();
+        assert_eq!(
+            get_allowed_emails_or_host(allowed_emails, &host).unwrap(),
+            "fifthtry.com"
+        );
+
+        let host = ft_sdk::Host("fifthtry.com".to_string());
+        let allowed_emails = "".to_string();
+        assert_eq!(
+            get_allowed_emails_or_host(allowed_emails, &host).unwrap(),
+            "fifthtry.com"
+        );
+
+        let host = ft_sdk::Host("fifthtry.com".to_string());
+        let allowed_emails = "capybara.com".to_string();
+        assert_eq!(
+            get_allowed_emails_or_host(allowed_emails, &host).unwrap(),
+            "capybara.com"
+        );
+    }
+
+    #[test]
+    fn test_is_special() {
+        // unverfied user with require_verification = false
+        let user = user_not_verified("test@mail.com");
+        let config = config_without_verification("mail.com");
+        let host = ft_sdk::Host("meet.fifthtry.com".to_string());
+        assert!(user.is_special(&config, &host).is_ok());
+
+        // unverified user with require_verification = true
+        let user = user_not_verified("test@mail.com");
+        let config = config_with_verification("mail.com");
+        assert_eq!(
+            user.is_special(&config, &host),
+            Err(AuthorizationError::RequiresVerification)
+        );
+
+        // verified user with require_verification = true
+        let user = user_verified("test@mail.com");
+        let config = config_with_verification("mail.com");
+        assert!(user.is_special(&config, &host).is_ok());
+
+        // verified user with require_verification = false
+        let user = user_verified("test@mail.com");
+        let config = config_without_verification("mail.com");
+        assert!(user.is_special(&config, &host).is_ok());
+
+        // verified user with empty allowed list but host matches
+        let user = user_verified("siddhant@fifthtry.com");
+        let config = config_without_verification("");
+        let host = ft_sdk::Host("fifthtry.com".to_string());
+        assert_eq!(user.is_special(&config, &host), Ok(()));
+        // verified user with empty allowed list and sub host
+        let host = ft_sdk::Host("talk.fifthtry.com".to_string());
+        let config = config_with_verification("");
+        assert!(user.is_special(&config, &host).is_ok());
+
+        // verified user with allowed list different from host
+        let host = ft_sdk::Host("fifthtry.com".to_string());
+        let config = config_with_verification("capybara.com");
+        let user = user_verified("siddhant@fifthtry.com");
+        assert!(user.is_special(&config, &host).is_err());
+        let user = user_verified("siddhant@capybara.com");
+        assert!(user.is_special(&config, &host).is_ok());
+
+        fn config_with_verification(emails: &str) -> crate::Config {
+            crate::Config {
+                allowed_emails: emails.to_string(),
+                require_verification: true,
+                ..Default::default()
+            }
+        }
+        fn config_without_verification(emails: &str) -> crate::Config {
+            crate::Config {
+                allowed_emails: emails.to_string(),
+                require_verification: false,
+                ..Default::default()
+            }
+        }
+        fn user_verified(email: &str) -> RequiredUser {
+            RequiredUser {
+                email: email.to_string(),
+                email_is_verified: true,
+                ..Default::default()
+            }
+        }
+        fn user_not_verified(email: &str) -> RequiredUser {
+            RequiredUser {
+                email: email.to_string(),
+                email_is_verified: false,
+                ..Default::default()
+            }
+        }
     }
 }

--- a/backend/src/create_meeting.rs
+++ b/backend/src/create_meeting.rs
@@ -24,14 +24,16 @@ fn create_meeting(
                     &scheme,
                     &host,
                     format!(
-                        "/{auth_wasm_name}/resend-confirmation-email/?email={email}",
-                        auth_wasm_name = crate::AUTH_WASM_NAME,
+                        "/backend/resend-confirmation-email/?email={email}",
                         email = user.email
                     )
                     .as_str(),
                 );
                 let link_text = match verification_link {
-                    Ok(v) => format!(" or [click here]({}) to get a new email", v.trim_end_matches('/')),
+                    Ok(v) => format!(
+                        " or [click here]({}) to get a new email",
+                        v.trim_end_matches('/')
+                    ),
                     Err(e) => {
                         ft_sdk::println!("Error creating verification link: {e}");
                         "".to_string()

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,6 +10,7 @@ mod session;
 mod token;
 
 const TALK_TOKEN_COOKIE: &str = "talk-token";
+const AUTH_WASM_NAME: &str = "email_auth_provider";
 
 fn create_session_cookie(
     token: &str,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,7 +10,6 @@ mod session;
 mod token;
 
 const TALK_TOKEN_COOKIE: &str = "talk-token";
-const AUTH_WASM_NAME: &str = "email_auth_provider";
 
 fn create_session_cookie(
     token: &str,

--- a/lets-talk-template.fifthtry.site/lets-talk.ftd
+++ b/lets-talk-template.fifthtry.site/lets-talk.ftd
@@ -4,10 +4,15 @@ export: dashboard-page, footer-badge, session, host-preset-name, participant-pre
 ;; Line starting with ";;" are comments. Changing/Removing them will not do anything.
 
 
-;; List of emails or email domains that are allowed to create new meetings
-;; This means that any email associated with fifthtry is able to create a meeting (siddhant@fifthtry.com for example)
-;; Change "fifthtry.com" below to "john@gmail.com" to only allow user with john@gmail.com email to create meetings
--- string who-can-create-meetings: fifthtry.com
+;; Emty value will let the server check emails against your host name.
+;; If your website is: https://mybusiness.com/ then, emails like support@mybusiness.com will be allowed to create meetings.
+;; Read below paragraphs to learn more about possible values to this variable.
+-- string who-can-create-meetings: $ftd.empty
+
+;; List of emails or email domains that are allowed to create new meetings.
+;; This means that any email associated with fifthtry is able to create a meeting (siddhant@fifthtry.com for example).
+;; Change "fifthtry.com" below to "john@gmail.com" to only allow user with john@gmail.com email to create meetings.
+;; -- string who-can-create-meetings: fifthtry.com
 
 
 ;; Other examples of values that can be set for `who-can-create-meetings` variable:

--- a/lets-talk.fifthtry.site/index.ftd
+++ b/lets-talk.fifthtry.site/index.ftd
@@ -39,5 +39,5 @@ decimal duration:
 
 
 ;;; List of emails or email domains that are allowed to create new meetings
-;;; siddhant@fifthtry.com, amitu@fifthtry.com etc are allowed to create a meeting
--- string who-can-create-meetings: fifthtry.com
+;;; The host name will be picked if this value is empty
+-- string who-can-create-meetings: $ftd.empty

--- a/lets-talk.fifthtry.site/index.ftd
+++ b/lets-talk.fifthtry.site/index.ftd
@@ -13,6 +13,15 @@ export: footer-badge
 -- ftd.temporary-redirect: /-/auth/signin/
 if: { lets-auth.user == NULL }
 
+-- boolean mail-sent: false
+$processor$: pr.request-data
+
+-- banner:
+close-link: /
+if: { mail-sent }
+
+An email to verify your account has been sent to your registered email address.
+
 -- lets-talk.dashboard-page: Dashboard
 past-sessions: $dummy.sessions
 
@@ -41,3 +50,26 @@ decimal duration:
 ;;; List of emails or email domains that are allowed to create new meetings
 ;;; The host name will be picked if this value is empty
 -- string who-can-create-meetings: $ftd.empty
+
+
+-- component banner:
+body content:
+string close-link:
+
+-- ds.column:
+background.solid: $ds.colors.background.step-1
+radius: $ds.radius.zero
+inset: $ds.spaces.inset-square.small 
+
+-- ds.row:
+spacing: $ds.spaces.horizontal-gap.small
+
+-- ds.copy-small: $banner.content
+-- ds.link: Close
+link: $banner.close-link
+
+-- end: ds.row
+
+-- end: ds.column
+
+-- end: banner


### PR DESCRIPTION
We match user's email against the host (website domain) if the
`who-can-create-meetings` variable is empty.

The error messages have also been improved:
- The error message will give you a link that you can use to receive a
  confirmation email to verify your account. This happens if your email
  matches the configuration of `who-can-create-meetings` but your
  account is not verified.

A bunch of tests have also been added to gain some confidence in logic.

For other cases, I'll later add an endpoint to check permissions and
hide the form UI based on it's value.


This has **no** breaking changes. It does not break the system interface (see lets-talk.fifthtry.site/index.ftd).

A banner appears on the dashboard page that let's the user know about the sent email status:

<img width="1672" alt="image" src="https://github.com/user-attachments/assets/c68ef34f-dddb-4b8f-b81b-410db81bd491" />
